### PR TITLE
Issues with HTML files

### DIFF
--- a/themes/actual_obsidian.json
+++ b/themes/actual_obsidian.json
@@ -20,14 +20,6 @@
 			}
 		},
 		{
-			"name": "Source base",
-			"scope": "source",
-			"settings": {
-				"background": "#293134",
-				"foreground": "#e0e2e4"
-			}
-		},
-		{
 			"name": "Comment",
 			"scope": "comment",
 			"settings": {

--- a/themes/actual_obsidian_legacy.json
+++ b/themes/actual_obsidian_legacy.json
@@ -20,14 +20,6 @@
 			}
 		},
 		{
-			"name": "Source base",
-			"scope": "source",
-			"settings": {
-				"background": "#293134",
-				"foreground": "#e0e2e4"
-			}
-		},
-		{
 			"name": "Comment",
 			"scope": "comment",
 			"settings": {


### PR DESCRIPTION
The `source` scope causes some issues with HTML files that contain `<script>` tags or `style="[...]"` attributes. The lowest scope for all files appears to be `text`, so removing the `source` scope shouldn't be an issue (hopefully).

Before:
![notfixed](https://user-images.githubusercontent.com/14052658/78501820-e9563580-7733-11ea-98cb-1aa6903496c4.png)

After:
![fixed](https://user-images.githubusercontent.com/14052658/78501823-ee1ae980-7733-11ea-877b-42e3fcd843c5.png)

